### PR TITLE
add custom base directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Variable | Description | Output Example
 --- | --- | ---
 `Entity` | Singular studly cased entity name | Order
 `Entities` | Plural studly cased entity name | Orders
+`Base` | Studly cased directory path | Order/Sub/Directory
+`Namespace` | Studly cased namespace | Order\Sub\Directory
 `collection` | Plural underscore cased entity name | orders
 `instance` | Singular underscore cased entity name | order
 `fields` | Associative multi-dimensional array of field names and attributes | `['name' => ['type' => 'string']]`


### PR DESCRIPTION
Referring to issue #13

Added support like @bkuhl suggested. This will enable to execute command like `blacksmith generate Foo.Foobar scaffold ~/path/to/config.json`. Also added a new template variable called `{{Base}}` to retrieve the base directory name

Signed-off-by: Ahmad Shah Hafizan Hamidin ahmadshahhafizan@gmail.com
